### PR TITLE
Correct README: Stripe integration is mode-agnostic, not test-only [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,4 @@ cargo test
 
 ## Scope and honesty
 
-A personal project, not a production processor: Stripe test mode, a single-admin
-model, and DynamoDB `scan`s where a real ledger would page or index. The point is
-the seams that are easy to get wrong — webhook idempotency, ACH settlement
-timing, signed sessions — handled and unit-tested (including a real captured
-Stripe event), not a checkout button that calls the API and hopes.
+A personal project, not a hardened production processor: a single-admin model and DynamoDB `scan`s where a real ledger would page or index. The Stripe integration is mode-agnostic — it runs against whichever secret key you supply (`sk_test_…` by default for the sandbox, `sk_live_…` for real charges, no code change). The point is the seams that are easy to get wrong — webhook idempotency, ACH settlement timing, signed sessions — handled and unit-tested (including a real captured Stripe event), not a checkout button that calls the API and hopes.


### PR DESCRIPTION
The "Scope and honesty" section claimed **Stripe test mode**, which is stale — the deployed Lambda has taken real money since 2026-06-13. Replaced that clause with an accurate, mode-agnostic description: it runs against whichever secret key is supplied (`sk_test_…` by default for the sandbox, `sk_live_…` for real charges, no code change). No code touched; README only.

Not merging this myself — per the repo's hard rule, a push to `main` is a live production deploy and needs your fresh approval. `[skip ci]` is in the subject so squash-merging this won't redeploy the Lambda.