### PR TITLE
Add a PR CI gate: fmt, clippy, test, web build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: ci
+
+# PR correctness gate for the payments Lambda: fmt + clippy (warnings = errors) +
+# tests for the Rust crate, and lint + build for the embedded web SPA. Runs on PRs
+# (and main) so a change that doesn't compile, fails a test, or is unformatted
+# can't merge — and merging main can deploy to prod. Holds no AWS creds and does
+# NOT deploy; the aarch64 cargo-lambda cross-build + deploy stay in main.yml.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      # keep the toolchain in sync with rust-toolchain.toml + main.yml — this
+      # action's RUSTUP_TOOLCHAIN overrides the file, so pin the channel here too
+      - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master 2026-07-02
+        with:
+          toolchain: nightly-2026-05-15
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: ${{ runner.os }}-cargo-check-${{ hashFiles('**/Cargo.lock') }}
+          cache-all-crates: "true"
+      - run: cargo fmt --check
+      - run: cargo clippy --all-targets -- -D warnings
+      - run: cargo test
+
+  web:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: "1.3.4"
+      - run: bun install --frozen-lockfile
+        working-directory: web
+      - run: bun run lint
+        working-directory: web
+      - run: bun run build
+        working-directory: web

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,19 +12,18 @@ use axum::{
     routing::{get, post},
     Router,
 };
+use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, Validation};
 use lambda_http::{http::StatusCode, run, tracing, Error};
 use serde::{Deserialize, Serialize};
 use stripe::Client as StripeClient;
 use stripe_checkout::checkout_session::{
-    CreateCheckoutSession, CreateCheckoutSessionLineItems,
-    CreateCheckoutSessionLineItemsPriceData, CreateCheckoutSessionPaymentMethodTypes, ProductData,
-    RetrieveCheckoutSession,
+    CreateCheckoutSession, CreateCheckoutSessionLineItems, CreateCheckoutSessionLineItemsPriceData,
+    CreateCheckoutSessionPaymentMethodTypes, ProductData, RetrieveCheckoutSession,
 };
 use stripe_checkout::CheckoutSessionMode;
 use stripe_shared::{CheckoutSession, CheckoutSessionPaymentStatus};
 use stripe_types::Currency;
 use stripe_webhook::{EventObject, EventType, Webhook};
-use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, Validation};
 use uuid::Uuid;
 
 // Item id 0 is the atomic counter that hands out sequential post ids. It
@@ -319,7 +318,7 @@ impl Db {
 
             invoices.extend(page.items().iter().filter_map(item_to_invoice));
 
-            start_key = page.last_evaluated_key().map(|key| key.clone());
+            start_key = page.last_evaluated_key().cloned();
             if start_key.is_none() {
                 break;
             }
@@ -417,7 +416,7 @@ async fn list_posts(State(db): State<Db>) -> Result<Json<Vec<Post>>, ServerError
 
         posts.extend(page.items().iter().filter_map(item_to_post));
 
-        start_key = page.last_evaluated_key().map(|key| key.clone());
+        start_key = page.last_evaluated_key().cloned();
         if start_key.is_none() {
             break;
         }
@@ -565,7 +564,10 @@ async fn get_session(
         id: session.id.to_string(),
         payment_status: payment_status_str(&session.payment_status),
         amount_total: session.amount_total,
-        currency: session.currency.as_ref().map(|currency| currency.to_string()),
+        currency: session
+            .currency
+            .as_ref()
+            .map(|currency| currency.to_string()),
     }))
 }
 
@@ -652,7 +654,7 @@ async fn list_payments(
 
         payments.extend(page.items().iter().filter_map(item_to_payment));
 
-        start_key = page.last_evaluated_key().map(|key| key.clone());
+        start_key = page.last_evaluated_key().cloned();
         if start_key.is_none() {
             break;
         }
@@ -940,7 +942,10 @@ async fn create_invoice(
     check_admin(&headers)?;
 
     if new.client_name.trim().is_empty() {
-        return Err((StatusCode::BAD_REQUEST, "client_name is required".to_string()));
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "client_name is required".to_string(),
+        ));
     }
     validate_line_items(&new.line_items)?;
 
@@ -1261,7 +1266,10 @@ mod tests {
 
     #[test]
     fn payment_status_maps_to_stable_strings() {
-        assert_eq!(payment_status_str(&CheckoutSessionPaymentStatus::Paid), "paid");
+        assert_eq!(
+            payment_status_str(&CheckoutSessionPaymentStatus::Paid),
+            "paid"
+        );
         assert_eq!(
             payment_status_str(&CheckoutSessionPaymentStatus::Unpaid),
             "unpaid"
@@ -1324,7 +1332,10 @@ mod tests {
     fn invoice_counter_item_is_not_an_invoice() {
         let counter = HashMap::from([
             ("id".to_string(), AttributeValue::S("counter".to_string())),
-            ("next_number".to_string(), AttributeValue::N("8".to_string())),
+            (
+                "next_number".to_string(),
+                AttributeValue::N("8".to_string()),
+            ),
         ]);
         assert!(item_to_invoice(&counter).is_none());
     }


### PR DESCRIPTION
## What

Adds `ci.yml` — the PR correctness gate the deploy path never provided. `main.yml` runs `cargo lambda build` + biome but **never `cargo clippy` or `cargo test`**, so lint/test regressions could only surface after merge (and merge deploys to prod). This adds, on `pull_request` (and `main`):

- **check** — `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo test`
- **web** — `bun install` + `bun run lint` + `bun run build`

To make the gate green on the current tree it also fixes the **3 existing `map_clone` clippy warnings** (`.map(|k| k.clone())` → `.cloned()`, behavior-identical) and reformats imports per the pinned rustfmt. clippy/fmt/test verified clean locally.

## Deploy note

`src/main.rs` is in the deploy path filter, so **merging this deploys** (behavior-preserving: formatting + `.cloned()`). Per this repo's hard rule I'm **not merging without your fresh approval**. After merge I'll add `required_status_checks` (`check`, `web`) to the ruleset so this gate is enforced.

No AWS creds in `ci.yml`; the aarch64 cross-build + deploy stay in `main.yml`.
