### PR TITLE
Deploy asserts PITR on the financial tables

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,3 +89,20 @@ jobs:
           STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
           OAUTH_CLIENT_SECRET: ${{ secrets.OAUTH_CLIENT_SECRET }}
           SESSION_SECRET: ${{ secrets.SESSION_SECRET }}
+
+      # Drift gate: PITR on the financial tables is declared in
+      # infra/storage.tf; fail the deploy if the live tables ever disagree
+      # (e.g. a console toggle), so backup posture can't rot silently.
+      - name: Verify PITR on the financial tables
+        run: |
+          set -euo pipefail
+          for t in accept-payments-payments accept-payments-invoices; do
+            status=$(aws dynamodb describe-continuous-backups --table-name "$t" \
+              --query 'ContinuousBackupsDescription.PointInTimeRecoveryDescription.PointInTimeRecoveryStatus' \
+              --output text)
+            if [ "$status" != "ENABLED" ]; then
+              echo "::error::PITR is $status on $t — must be ENABLED (declared in infra/storage.tf)"
+              exit 1
+            fi
+            echo "$t: PITR $status"
+          done

--- a/infra/oidc.tf
+++ b/infra/oidc.tf
@@ -66,6 +66,16 @@ resource "aws_iam_role_policy" "github_deploy" {
         Effect   = "Allow"
         Action   = ["iam:PassRole"]
         Resource = [aws_iam_role.cargo-lambda-role.arn]
+      },
+      {
+        # The deploy's drift gate reads live PITR status on the financial
+        # tables and fails if it disagrees with storage.tf. Read-only.
+        Effect   = "Allow"
+        Action   = ["dynamodb:DescribeContinuousBackups"]
+        Resource = [
+          aws_dynamodb_table.payments.arn,
+          aws_dynamodb_table.invoices.arn,
+        ]
       }
     ]
   })


### PR DESCRIPTION
PITR on `payments` + `invoices` is declared in `infra/storage.tf` and enabled live, but nothing would notice drift (e.g. a console toggle). This adds:

- a post-deploy step that reads `DescribeContinuousBackups` on both tables and fails the run if either is not `ENABLED`;
- the matching read-only grant on the deploy role, scoped to the two table ARNs (terraform plan: `0 to add, 1 to change, 0 to destroy`).

Note: merging deploys (`main.yml` is in its own path filter), and the workflow change only takes effect once the role grant is applied — apply `infra/` before or with the merge.