### PR TITLE
ci: lock cargo invocations, pin cargo-lambda

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,8 @@ jobs:
           key: ${{ runner.os }}-cargo-check-${{ hashFiles('**/Cargo.lock') }}
           cache-all-crates: "true"
       - run: cargo fmt --check
-      - run: cargo clippy --all-targets -- -D warnings
-      - run: cargo test
+      - run: cargo clippy --all-targets --locked -- -D warnings
+      - run: cargo test --locked
 
   web:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
         working-directory: web
       - run: bun run build
         working-directory: web
-      - run: pip3 install cargo-lambda
+      - run: pip3 install cargo-lambda==1.9.1
       - run: cargo lambda build --release --arm64 --features embed-web
 
       # Short-lived credentials via GitHub OIDC: the role trusts only pushes


### PR DESCRIPTION
- `--locked` on clippy + test (Cargo.lock is committed; drift now fails loudly)
- `pip3 install cargo-lambda==1.9.1` in the deploy, matching the version pinned elsewhere