### PR TITLE
web: pin the dev server to an uncommon port with strictPort

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The API needs AWS credentials (DynamoDB) and, for live payments, Stripe keys:
 
 ```sh
 cargo lambda watch                 # API, local
-cd web && bun install && bun dev   # SPA at http://localhost:5173
+cd web && bun install && bun dev   # SPA at http://localhost:47305
 ```
 
 Without `STRIPE_SECRET_KEY` / `STRIPE_WEBHOOK_SECRET` the payment routes return

--- a/src/main.rs
+++ b/src/main.rs
@@ -177,7 +177,7 @@ struct Db {
     // None until the Stripe secrets are configured; payment routes 503 cleanly
     stripe: Option<StripeClient>,
     webhook_secret: Option<String>,
-    // origin of the SPA (e.g. http://localhost:5173); checkout redirect URLs
+    // origin of the SPA (e.g. http://localhost:47305); checkout redirect URLs
     // point here, falling back to the request host when unset
     web_origin: Option<String>,
     invoices_table: String,

--- a/web/README.md
+++ b/web/README.md
@@ -8,7 +8,7 @@ Frontend for accept-payments — a Vite + React + TypeScript SPA using
 
 ```bash
 bun install
-bun dev            # http://localhost:5173
+bun dev            # http://localhost:47305
 ```
 
 The receipt route is `/success?session_id=<id>` — Stripe Checkout's

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -20,6 +20,10 @@ export default defineConfig({
     },
   },
   server: {
+    // Uncommon pinned port; strict so a taken port fails loudly instead of
+    // silently shifting.
+    port: 47305,
+    strictPort: true,
     proxy: {
       // The SPA calls /sessions/:id same-origin; in dev, forward it to the Rust
       // Lambda (cargo lambda watch, or API_PROXY_TARGET). In production the


### PR DESCRIPTION
Dev-only: `port: 47305, strictPort: true` replaces the default 5173; the two README mentions and the main.rs CORS example comment follow.